### PR TITLE
Fix failing test issue #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 target
 mods
 bin
+*.iml
+*.ipr
+*.iws

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
         <!--Dependency versions -->
         <pac4j.version>1.7.0-SNAPSHOT</pac4j.version>
-        <vertx.version>2.1RC2</vertx.version>
+        <vertx.version>2.1.5</vertx.version>
         <vertx.testtools.version>2.0.3-final</vertx.testtools.version>
         <junit.version>4.11</junit.version>
 
@@ -140,6 +140,18 @@
                         <target>1.7</target>
                     </configuration>
                 </plugin>
+ <plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-source-plugin</artifactId>
+		<executions>
+			<execution>
+				<id>attach-sources</id>
+				<goals>
+					<goal>jar</goal>
+				</goals>
+			</execution>
+		</executions>
+	   </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/vertx-pac4j-core/pom.xml
+++ b/vertx-pac4j-core/pom.xml
@@ -54,6 +54,18 @@
             <artifactId>vertx-core</artifactId>
             <version>${vertx.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>  <!-- declare the exclusion here -->
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.5.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Test is using method from package  com.fasterxml.jackson.core. This methdo is
not available in version 2.2.2 which io.vertx:vertx.core loads. So
explicitely load newer version.