### PR TITLE
#17 Make public handler API use Config objects

### DIFF
--- a/src/main/java/org/pac4j/vertx/handler/impl/BasePac4JAuthHandler.java
+++ b/src/main/java/org/pac4j/vertx/handler/impl/BasePac4JAuthHandler.java
@@ -9,7 +9,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.impl.AuthHandlerImpl;
-import org.pac4j.core.client.Clients;
+import org.pac4j.core.config.Config;
 import org.pac4j.core.context.BaseConfig;
 import org.pac4j.core.context.Pac4jConstants;
 import org.pac4j.core.profile.UserProfile;
@@ -35,9 +35,9 @@ public abstract class BasePac4JAuthHandler extends AuthHandlerImpl implements Pa
   protected final String clientName;
   protected final Pac4jAuthProvider pac4jAuthProvider;
 
-  public BasePac4JAuthHandler(final Vertx vertx, final Clients clients, final Pac4jAuthProvider authProvider,
+  public BasePac4JAuthHandler(final Vertx vertx, final Config config, final Pac4jAuthProvider authProvider,
                               final Pac4jAuthHandlerOptions options) {
-    this(new Pac4jWrapper(vertx, clients), authProvider, options);
+    this(new Pac4jWrapper(vertx, config), authProvider, options);
   }
 
   public BasePac4JAuthHandler(final Pac4jWrapper wrapper,

--- a/src/main/java/org/pac4j/vertx/handler/impl/StatefulPac4jAuthHandler.java
+++ b/src/main/java/org/pac4j/vertx/handler/impl/StatefulPac4jAuthHandler.java
@@ -5,7 +5,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-import org.pac4j.core.client.Clients;
+import org.pac4j.core.config.Config;
 import org.pac4j.vertx.Pac4jAuthenticationResponse;
 import org.pac4j.vertx.Pac4jSessionAttributes;
 import org.pac4j.vertx.VertxWebContext;
@@ -18,11 +18,11 @@ public class StatefulPac4jAuthHandler extends BasePac4JAuthHandler {
 
   // Consider coalescing the manager options into the handler options and then generating the manageroptions from them
   public StatefulPac4jAuthHandler(final Vertx vertx,
-                                  final Clients clients,
+                                  final Config config,
                                   final Router router,
                                   final Pac4jAuthProvider authProvider,
                                   final Pac4jAuthHandlerOptions options) {
-    super(vertx, clients, authProvider, options);
+    super(vertx, config, authProvider, options);
 
     // Start manager verticle
     router.route(HttpMethod.GET, "/authResult").handler(authResultHandler(options));

--- a/src/main/java/org/pac4j/vertx/handler/impl/StatelessPac4jAuthHandler.java
+++ b/src/main/java/org/pac4j/vertx/handler/impl/StatelessPac4jAuthHandler.java
@@ -3,7 +3,7 @@ package org.pac4j.vertx.handler.impl;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.RoutingContext;
-import org.pac4j.core.client.Clients;
+import org.pac4j.core.config.Config;
 import org.pac4j.vertx.Pac4jAuthenticationResponse;
 import org.pac4j.vertx.Pac4jSessionAttributes;
 import org.pac4j.vertx.auth.Pac4jAuthProvider;
@@ -15,10 +15,10 @@ import org.pac4j.vertx.auth.Pac4jAuthProvider;
 public class StatelessPac4jAuthHandler extends BasePac4JAuthHandler {
 
   public StatelessPac4jAuthHandler(final Vertx vertx,
-                                   final Clients clients,
+                                   final Config config,
                                    final Pac4jAuthProvider authProvider,
                                    final Pac4jAuthHandlerOptions options) {
-    super(vertx, clients, authProvider, options);
+    super(vertx, config, authProvider, options);
 
   }
 

--- a/src/test/java/org/pac4j/vertx/StatefulPac4jAuthHandlerIntegrationTest.java
+++ b/src/test/java/org/pac4j/vertx/StatefulPac4jAuthHandlerIntegrationTest.java
@@ -4,7 +4,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.AuthHandler;
 import io.vertx.ext.web.handler.CookieHandler;
@@ -14,6 +13,7 @@ import io.vertx.ext.web.sstore.SessionStore;
 import org.junit.Test;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
+import org.pac4j.core.config.Config;
 import org.pac4j.vertx.auth.Pac4jAuthProvider;
 import org.pac4j.vertx.auth.StatefulPac4jAuthProvider;
 import org.pac4j.vertx.client.TestOAuth2AuthorizationGenerator;
@@ -190,7 +190,7 @@ public class StatefulPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerInt
     DefaultJsonConverter ebConverter = new DefaultJsonConverter();
     Pac4jAuthProvider authProvider = StatefulPac4jAuthProvider.create(sessionStore, ebConverter);
     Pac4jAuthHandlerOptions options = new Pac4jAuthHandlerOptions(TEST_CLIENT_NAME);
-    return new StatefulPac4jAuthHandler(vertx, clients(client(baseAuthUrl)), router, authProvider, options);
+    return new StatefulPac4jAuthHandler(vertx, config(client(baseAuthUrl)), router, authProvider, options);
   }
 
   private void redirectToUrl(final String redirectUrl, final HttpClient client, final Handler<HttpClientResponse> resultHandler) {
@@ -204,31 +204,10 @@ public class StatefulPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerInt
     return Optional.ofNullable(sessionCookie.get());
   }
 
-
-  private JsonObject clientConfig(final String baseAuthUrl) {
-    return new JsonObject()
-      .put("callbackUrl", "http://localhost:8080/authResult")
-      .put("clients", clients(baseAuthUrl));
-  }
-
-  private JsonObject clients(final String baseAuthUrl) {
-    return new JsonObject()
-      .put("testClient", new JsonObject()
-        .put("class", TestOAuth2Client.class.getName())
-        .put("props", testClientProps(baseAuthUrl)));
-  }
-
-  private JsonObject testClientProps(final String baseAuthUrl) {
-    return new JsonObject()
-      .put("key", TEST_CLIENT_ID)
-      .put("secret", TEST_CLIENT_SECRET)
-      .put("authorizationUrlTemplate", baseAuthUrl + "?client_id=%s&redirect_uri=%s&state=%s");
-  }
-
-  private Clients clients(final Client client) {
-    Clients clients = new Clients();
+  private Config config(final Client client) {
+    final Clients clients = new Clients();
     clients.setClients(client);
-    return clients;
+    return new Config(clients);
   }
 
   private TestOAuth2Client client(final String baseAuthUrl) {

--- a/src/test/java/org/pac4j/vertx/StatelessPac4jAuthHandlerIntegrationTest.java
+++ b/src/test/java/org/pac4j/vertx/StatelessPac4jAuthHandlerIntegrationTest.java
@@ -8,6 +8,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
+import org.pac4j.core.config.Config;
 import org.pac4j.http.client.direct.DirectBasicAuthClient;
 import org.pac4j.http.credentials.authenticator.test.SimpleTestUsernamePasswordAuthenticator;
 import org.pac4j.http.profile.creator.test.SimpleTestUsernameProfileCreator;
@@ -60,13 +61,14 @@ public class StatelessPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerIn
     // Configure a pac4j stateless handler configured for basic http auth
     final Pac4jAuthProvider authProvider = new StatelessPac4jAuthProviderImpl();
     Pac4jAuthHandlerOptions options = new Pac4jAuthHandlerOptions("BasicAuthClient");
-    final StatelessPac4jAuthHandler handler =  new StatelessPac4jAuthHandler(vertx, clients(), authProvider, options);
+    final StatelessPac4jAuthHandler handler =  new StatelessPac4jAuthHandler(vertx, config(), authProvider, options);
     startWebServer(router, handler);
 
   }
 
-  private Clients clients() {
-    return new Clients(client());
+  private Config config() {
+    final Clients clients = new Clients(client());
+    return new Config(clients);
   }
 
   private Client client() {


### PR DESCRIPTION
#17 Make public handler API use Config objects

Use config objects in public API for consistency with existing Pac4j idioms