### PR TITLE
Issue #40 Use the authorization checker functionality in Pac4j for authorization

### DIFF
--- a/src/main/java/org/pac4j/vertx/handler/impl/Pac4jAuthHandlerOptions.java
+++ b/src/main/java/org/pac4j/vertx/handler/impl/Pac4jAuthHandlerOptions.java
@@ -15,23 +15,29 @@
  */
 package org.pac4j.vertx.handler.impl;
 
+import java.util.Objects;
+
 /**
  * @author Jeremy Prime
  * @since 2.0.0
  */
 public class Pac4jAuthHandlerOptions {
 
-  private final String clientName;
+    private final String clientName;
+    private final String authorizerName;
 
-  public Pac4jAuthHandlerOptions(String clientName) {
-    if (clientName == null) {
-      throw new IllegalArgumentException("clientName must not be null");
+    public Pac4jAuthHandlerOptions(final String clientName, final String authorizerName) {
+        Objects.requireNonNull(clientName);
+        Objects.requireNonNull(authorizerName);
+        this.clientName = clientName;
+        this.authorizerName = authorizerName;
     }
-    this.clientName = clientName;
-  }
 
-  public String clientName() {
-    return clientName;
-  }
+    public String clientName() {
+        return clientName;
+    }
 
+    public String authorizerName() {
+        return authorizerName;
+    }
 }

--- a/src/main/java/org/pac4j/vertx/http/DefaultHttpActionAdapter.java
+++ b/src/main/java/org/pac4j/vertx/http/DefaultHttpActionAdapter.java
@@ -37,7 +37,6 @@ public class DefaultHttpActionAdapter implements HttpActionAdapter {
         } else if (code == HttpConstants.FORBIDDEN) {
             sendResponse(context, HttpConstants.FORBIDDEN, "Forbidden");
         } else if (code == HttpConstants.TEMP_REDIRECT) {
-
             redirect(context.getResponseLocation(), context);
         } else if (code == HttpConstants.OK) {
             // Content should already have been written

--- a/src/test/java/org/pac4j/vertx/Pac4jAuthHandlerIntegrationTestBase.java
+++ b/src/test/java/org/pac4j/vertx/Pac4jAuthHandlerIntegrationTestBase.java
@@ -21,7 +21,13 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.StaticHandler;
 import io.vertx.test.core.VertxTestBase;
+import org.pac4j.core.authorization.Authorizer;
+import org.pac4j.core.authorization.RequireAllPermissionsAuthorizer;
+import org.pac4j.vertx.profile.TestOAuth2Profile;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -32,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 public abstract class Pac4jAuthHandlerIntegrationTestBase extends VertxTestBase {
 
     protected static final String TEST_CLIENT_NAME = "TestOAuth2Client";
+    protected static final String REQUIRE_ALL_AUTHORIZER = "requireAllAuthorizer";
 
     protected void startWebServer(Router router, Handler<RoutingContext> authHandler) throws Exception {
         HttpServer server = vertx.createHttpServer();
@@ -50,4 +57,15 @@ public abstract class Pac4jAuthHandlerIntegrationTestBase extends VertxTestBase 
         assertTrue(latch.await(1L, TimeUnit.SECONDS));
     }
 
+    protected Map<String, Authorizer> authorizers(final List<String> permissions) {
+        return new HashMap<String, Authorizer>() {{
+            put(REQUIRE_ALL_AUTHORIZER, authorizer(permissions));
+        }};
+    }
+
+    private RequireAllPermissionsAuthorizer<TestOAuth2Profile> authorizer(final List<String> permissions) {
+        final RequireAllPermissionsAuthorizer<TestOAuth2Profile> authorizer = new RequireAllPermissionsAuthorizer<TestOAuth2Profile>();
+        authorizer.setPermissions(permissions);
+        return authorizer;
+    }
 }

--- a/src/test/java/org/pac4j/vertx/StatelessPac4jAuthHandlerIntegrationTest.java
+++ b/src/test/java/org/pac4j/vertx/StatelessPac4jAuthHandlerIntegrationTest.java
@@ -29,6 +29,7 @@ import org.pac4j.vertx.auth.Pac4jAuthProvider;
 import org.pac4j.vertx.handler.impl.Pac4jAuthHandlerOptions;
 import org.pac4j.vertx.handler.impl.RequiresAuthenticationHandler;
 
+import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -90,7 +91,7 @@ public class StatelessPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerIn
         final Router router = Router.router(vertx);
         // Configure a pac4j stateless handler configured for basic http auth
         final Pac4jAuthProvider authProvider = new Pac4jAuthProvider();
-        Pac4jAuthHandlerOptions options = new Pac4jAuthHandlerOptions("BasicAuthClient");
+        Pac4jAuthHandlerOptions options = new Pac4jAuthHandlerOptions("BasicAuthClient", REQUIRE_ALL_AUTHORIZER);
         final RequiresAuthenticationHandler handler =  new RequiresAuthenticationHandler(vertx, config(), authProvider, options);
         startWebServer(router, handler);
 
@@ -98,7 +99,7 @@ public class StatelessPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerIn
 
     private Config config() {
         final Clients clients = new Clients(client());
-        return new Config(clients);
+        return new Config(clients, authorizers(new ArrayList<String>()));
     }
 
     private Client client() {


### PR DESCRIPTION
Issue #40 Use the authorization checker functionality in Pac4j for authorization

We've now amended the vertx-pac4j implementation to use the newly-introduced
client finder functionality to determine the client to use.

The second part of this issue relates to using the pac4j 1.8 authorization checker
functionality. Override the current authorise method so that it will use the pac4j auth
checkers and amend tests accordingly.

Note that we've chosen to override the authorise function inherited from the vert.x base
auth handler class. This is so that if someone familiar with vert.x wishes to use their own
mechanism for authorization, bypassing entirely the Pac4j authorization infrastructure,
they can override the standard method exposed by the vert.x handler for doing so. I'm
not sure why someone would choose to do that, but this way they have the option to do
so, or to write their own Pac4j authorizer. Either approach will work.

Note that this will also resolve issue #23 - use Pac4j authorization