### PR TITLE
Issue #48 RequiresAuthenticationHandler (and derivatives) should not require an authorizer name to be set

### DIFF
--- a/src/main/java/org/pac4j/vertx/handler/impl/Pac4jAuthHandlerOptions.java
+++ b/src/main/java/org/pac4j/vertx/handler/impl/Pac4jAuthHandlerOptions.java
@@ -23,14 +23,19 @@ import java.util.Objects;
  */
 public class Pac4jAuthHandlerOptions {
 
-    private final String clientName;
-    private final String authorizerName;
+    private String clientName = "";
+    private String authorizerName = "";
 
-    public Pac4jAuthHandlerOptions(final String clientName, final String authorizerName) {
-        Objects.requireNonNull(clientName);
-        Objects.requireNonNull(authorizerName);
-        this.clientName = clientName;
-        this.authorizerName = authorizerName;
+    public Pac4jAuthHandlerOptions withClientName(final String newName) {
+        Objects.requireNonNull(newName);
+        clientName = newName;
+        return this;
+    }
+
+    public Pac4jAuthHandlerOptions withAuthorizerName(final String newName) {
+        Objects.requireNonNull(newName);
+        authorizerName = newName;
+        return this;
     }
 
     public String clientName() {

--- a/src/test/java/org/pac4j/vertx/StatelessPac4jAuthHandlerIntegrationTest.java
+++ b/src/test/java/org/pac4j/vertx/StatelessPac4jAuthHandlerIntegrationTest.java
@@ -44,6 +44,7 @@ public class StatelessPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerIn
     private static final String TEST_BASIC_AUTH_HEADER = BASIC_AUTH_PREFIX + Base64.encodeBase64String("testUser:testUser".getBytes());
     private static final String TEST_FAILING_BASIC_AUTH_HEADER = BASIC_AUTH_PREFIX + Base64.encodeBase64String("testUser:testUser2".getBytes());
     public static final String PROTECTED_RESOURCE_URL = "/private/success.html";
+    public static final String BASIC_AUTH_CLIENT = "BasicAuthClient";
 
     @Test
     public void testSuccessfulLogin() throws Exception {
@@ -91,7 +92,9 @@ public class StatelessPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerIn
         final Router router = Router.router(vertx);
         // Configure a pac4j stateless handler configured for basic http auth
         final Pac4jAuthProvider authProvider = new Pac4jAuthProvider();
-        Pac4jAuthHandlerOptions options = new Pac4jAuthHandlerOptions("BasicAuthClient", REQUIRE_ALL_AUTHORIZER);
+        Pac4jAuthHandlerOptions options = new Pac4jAuthHandlerOptions()
+                .withAuthorizerName(REQUIRE_ALL_AUTHORIZER)
+                .withClientName(BASIC_AUTH_CLIENT);
         final RequiresAuthenticationHandler handler =  new RequiresAuthenticationHandler(vertx, config(), authProvider, options);
         startWebServer(router, handler);
 


### PR DESCRIPTION
Issue #48 RequiresAuthenticationHandler (and derivatives) should not require an authorizer name to be set

Previously RequiresAuthenticationHandler and its derivatives mandate that an authorizer name be supplied on instantiation (via the Pac4jAuthHandlerOptions constructor). This is inconsistent with the play-pac4j implementation and more critically means that if an authorizer is required for any endpoint protected by Pac4j, an authorizer is required for all endpoints.

Modify the RequiresAuthenticationHandler and its derivatives to ensure that authorizer name and client name are not necessary and default to empty string (as per play-pac4j implementation). Where authorizer name is not supplied, then authorization should succeed on that endpoint for all authenticated users.