### PR TITLE
Issue#55 Add principal to Pac4jUser and add user to RoutingContext on…

### DIFF
--- a/src/main/java/org/pac4j/vertx/auth/Pac4jUser.java
+++ b/src/main/java/org/pac4j/vertx/auth/Pac4jUser.java
@@ -30,9 +30,14 @@ import org.pac4j.core.profile.UserProfile;
 public class Pac4jUser extends AbstractUser {
 
   private final UserProfile userProfile;
+  private final JsonObject principal;
 
   public Pac4jUser(UserProfile userProfile) {
     this.userProfile = userProfile;
+    principal = new JsonObject();
+    userProfile.getAttributes().keySet().stream().forEach(key -> {
+      principal.put(key, userProfile.getAttribute(key));
+    });
   }
 
   @Override
@@ -46,7 +51,7 @@ public class Pac4jUser extends AbstractUser {
 
   @Override
   public JsonObject principal() {
-    return null;
+    return principal;
   }
 
   @Override

--- a/src/main/java/org/pac4j/vertx/handler/impl/RequiresAuthenticationHandler.java
+++ b/src/main/java/org/pac4j/vertx/handler/impl/RequiresAuthenticationHandler.java
@@ -174,6 +174,7 @@ public class RequiresAuthenticationHandler extends AuthHandlerImpl {
         // blocking i/o such as database lookups
         vertx.executeBlocking(future -> {
                     future.complete(authorizationChecker.isAuthorized(new VertxWebContext(context), ((Pac4jUser) user).pac4jUserProfile(), authorizerName, config.getAuthorizers()));
+                    context.setUser(user);
                 },
                 authHandler
         );


### PR DESCRIPTION
… authorize

The user has to be added to the RoutingContext, I'm not sure if I chose the best spot to do this.

Also returning null as vertx user principal is not too nice. I gave it a try with a very simple conversion to JsonObject, works fine for me.