### PR TITLE
multiple code improvements: squid:S1226, squid:MethodCyclomaticComplexity, squid:EmptyStatementUsageCheck

### DIFF
--- a/src/main/java/org/pac4j/vertx/auth/Pac4jUser.java
+++ b/src/main/java/org/pac4j/vertx/auth/Pac4jUser.java
@@ -76,15 +76,15 @@ public class Pac4jUser extends AbstractUser {
 
     @Override
     public int readFromBuffer(int pos, Buffer buffer) {
-        pos = super.readFromBuffer(pos, buffer);
-        final int jsonByteCount = buffer.getInt(pos);
-        pos += 4;
-        final byte[] jsonBytes = buffer.getBytes(pos, pos + jsonByteCount);
-        pos += jsonByteCount;
+        int posLocal = super.readFromBuffer(pos, buffer);
+        final int jsonByteCount = buffer.getInt(posLocal);
+        posLocal += 4;
+        final byte[] jsonBytes = buffer.getBytes(posLocal, posLocal + jsonByteCount);
+        posLocal += jsonByteCount;
         final String json = new String(jsonBytes, StandardCharsets.UTF_8);
         final UserProfile userProfile = (UserProfile) DefaultJsonConverter.getInstance().decodeObject(json);
         setUserProfile(userProfile);
-        return pos;
+        return posLocal;
     }
 
     public UserProfile pac4jUserProfile() {

--- a/src/main/java/org/pac4j/vertx/core/DefaultJsonConverter.java
+++ b/src/main/java/org/pac4j/vertx/core/DefaultJsonConverter.java
@@ -80,9 +80,7 @@ public class DefaultJsonConverter implements JsonConverter {
         } else if (value instanceof Object[]) {
             Object[] src = ((Object[]) value);
             List<Object> list = new ArrayList<>(src.length);
-            for (Object object : src) {
-                list.add(encodeObject(object));
-            }
+            fillEncodedList(src, list);
             return new JsonArray(list);
         } else {
             try {
@@ -91,6 +89,12 @@ public class DefaultJsonConverter implements JsonConverter {
             } catch (Exception e) {
                 throw new TechnicalException("Error while encoding object", e);
             }
+        }
+    }
+
+    private void fillEncodedList(Object[] src, List<Object> list) {
+        for (Object object : src) {
+            list.add(encodeObject(object));
         }
     }
 
@@ -103,19 +107,27 @@ public class DefaultJsonConverter implements JsonConverter {
         } else if (value instanceof JsonArray) {
             JsonArray src = (JsonArray) value;
             List<Object> list = new ArrayList<>(src.size());
-            for (Object object : src) {
-                list.add(decodeObject(object));
-            }
+            fillDecodedList(src, list);
             return list.toArray();
         } else if (value instanceof JsonObject) {
             JsonObject src = (JsonObject) value;
-            try {
-                return decode(src.getJsonObject("value").encode(), Class.forName(src.getString("class")));
-            } catch (Exception e) {
-                throw new TechnicalException("Error while decoding object", e);
-            }
+            return decode(src);
         }
         return null;
+    }
+
+    private Object decode(JsonObject src) {
+        try {
+            return decode(src.getJsonObject("value").encode(), Class.forName(src.getString("class")));
+        } catch (Exception e) {
+            throw new TechnicalException("Error while decoding object", e);
+        }
+    }
+
+    private void fillDecodedList(JsonArray src, List<Object> list) {
+        for (Object object : src) {
+            list.add(decodeObject(object));
+        }
     }
 
     private boolean isPrimitiveType(Object value) {
@@ -138,20 +150,20 @@ public class DefaultJsonConverter implements JsonConverter {
         @JsonCreator
         public BearerAccessTokenMixin(@JsonProperty("value") String value, @JsonProperty("lifetime") long lifetime,
                 @JsonProperty("scope") Scope scope) {
-        };
+        }
     }
 
     public static class ValueMixin {
         @JsonCreator
         public ValueMixin(@JsonProperty("value") String value, @JsonProperty("requirement") Requirement requirement) {
-        };
+        }
     }
 
     public static class TokenMixin {
         @JsonCreator
         public TokenMixin(@JsonProperty("token") String token, @JsonProperty("secret") String secret,
                 @JsonProperty("rawResponse") String rawResponse) {
-        };
+        }
     }
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1226 Method parameters, caught exceptions and foreach variables should not be reassigned.
squid:MethodCyclomaticComplexity Methods should not be too complex.
squid:EmptyStatementUsageCheck Empty statements should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1226
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AMethodCyclomaticComplexity
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AEmptyStatementUsageCheck
Please let me know if you have any questions.
George Kankava