### PR TITLE
multiple code improvements squid:HiddenFieldCheck, squid:S1068, squid:S1155

### DIFF
--- a/src/main/java/org/pac4j/vertx/VertxWebContext.java
+++ b/src/main/java/org/pac4j/vertx/VertxWebContext.java
@@ -194,10 +194,9 @@ public class VertxWebContext extends BaseResponseContext {
 
     @Override
     public Map<String, String> getResponseHeaders() {
-        Map<String, String> headers =  routingContext.response().headers().entries().stream()
+        return routingContext.response().headers().entries().stream()
             .collect(Collectors.toMap((Function<Map.Entry<String, String>, String>) Map.Entry::getKey,
                     (Function<Map.Entry<String, String>, String>) Map.Entry::getValue));
-        return headers;
     }
 
     @Override

--- a/src/main/java/org/pac4j/vertx/auth/Pac4jUser.java
+++ b/src/main/java/org/pac4j/vertx/auth/Pac4jUser.java
@@ -82,8 +82,8 @@ public class Pac4jUser extends AbstractUser {
         final byte[] jsonBytes = buffer.getBytes(pos, pos + jsonByteCount);
         pos += jsonByteCount;
         final String json = new String(jsonBytes, StandardCharsets.UTF_8);
-        final UserProfile userProfile = (UserProfile) DefaultJsonConverter.getInstance().decodeObject(json);
-        setUserProfile(userProfile);
+        final UserProfile decodedUserProfile = (UserProfile) DefaultJsonConverter.getInstance().decodeObject(json);
+        setUserProfile(decodedUserProfile);
         return pos;
     }
 

--- a/src/main/java/org/pac4j/vertx/cas/VertxClusteredSharedDataLogoutHandler.java
+++ b/src/main/java/org/pac4j/vertx/cas/VertxClusteredSharedDataLogoutHandler.java
@@ -15,8 +15,6 @@
  */
 package org.pac4j.vertx.cas;
 
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.rxjava.core.Vertx;
 import org.pac4j.core.exception.TechnicalException;
 
@@ -30,8 +28,6 @@ import java.util.concurrent.TimeoutException;
  * @since 2.0.0
  */
 public class VertxClusteredSharedDataLogoutHandler extends VertxSharedDataLogoutHandler {
-
-    private static final Logger LOG = LoggerFactory.getLogger(VertxClusteredSharedDataLogoutHandler.class);
 
     private final Vertx rxVertx;
 

--- a/src/main/java/org/pac4j/vertx/cas/VertxLocalSharedDataLogoutHandler.java
+++ b/src/main/java/org/pac4j/vertx/cas/VertxLocalSharedDataLogoutHandler.java
@@ -16,8 +16,6 @@
 package org.pac4j.vertx.cas;
 
 import io.vertx.core.Vertx;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.ext.web.sstore.SessionStore;
 
@@ -26,8 +24,6 @@ import io.vertx.ext.web.sstore.SessionStore;
  * @since 2.0.0
  */
 public class VertxLocalSharedDataLogoutHandler extends VertxSharedDataLogoutHandler {
-
-    private static final Logger LOG = LoggerFactory.getLogger(VertxLocalSharedDataLogoutHandler.class);
 
     public VertxLocalSharedDataLogoutHandler(final Vertx vertx, final SessionStore sessionStore) {
         this(vertx, sessionStore, 1);

--- a/src/main/java/org/pac4j/vertx/handler/impl/RequiresAuthenticationHandler.java
+++ b/src/main/java/org/pac4j/vertx/handler/impl/RequiresAuthenticationHandler.java
@@ -194,11 +194,11 @@ public class RequiresAuthenticationHandler extends AuthHandlerImpl {
     }
 
     protected boolean useSession(final WebContext context, final List<Client> currentClients) {
-        return currentClients == null || currentClients.size() == 0 || currentClients.get(0) instanceof IndirectClient;
+        return currentClients == null || currentClients.isEmpty() || currentClients.get(0) instanceof IndirectClient;
     }
 
     protected boolean startAuthentication(final VertxWebContext context, final List<Client> currentClients) {
-        return currentClients != null && currentClients.size() > 0 && currentClients.get(0) instanceof IndirectClient;
+        return currentClients != null && !currentClients.isEmpty() && currentClients.get(0) instanceof IndirectClient;
     }
 
     protected void saveRequestedUrl(final WebContext context, final List<Client> currentClients) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1155 Collection.isEmpty() should be used to test for emptiness.
squid:HiddenFieldCheck Local variables should not shadow class fields.
squid:S1068 Unused private fields should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AHiddenFieldCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1068
Please let me know if you have any questions.
George Kankava