### PR TITLE
squid:S1172 Unused method parameters should be removed

### DIFF
--- a/src/main/java/org/pac4j/vertx/handler/impl/CallbackDeployingPac4jAuthHandler.java
+++ b/src/main/java/org/pac4j/vertx/handler/impl/CallbackDeployingPac4jAuthHandler.java
@@ -68,10 +68,10 @@ public class CallbackDeployingPac4jAuthHandler extends RequiresAuthenticationHan
         }
 
         // Start manager verticle
-        router.route(HttpMethod.GET, uri.getPath()).handler(authResultHandler(vertx, config, options));
+        router.route(HttpMethod.GET, uri.getPath()).handler(authResultHandler(vertx, config));
     }
 
-    private Handler<RoutingContext> authResultHandler(final Vertx vertx, final Config config, Pac4jAuthHandlerOptions options) {
+    private Handler<RoutingContext> authResultHandler(final Vertx vertx, final Config config) {
         return new CallbackHandler(vertx, config);
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1172 Unused method parameters should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1172
Please let me know if you have any questions.
George Kankava