### PR TITLE
Issue #72 Implement multi-profile support in vertx-pac4j

### DIFF
--- a/src/main/java/org/pac4j/vertx/handler/impl/SecurityHandler.java
+++ b/src/main/java/org/pac4j/vertx/handler/impl/SecurityHandler.java
@@ -32,7 +32,7 @@ public class SecurityHandler extends AuthHandlerImpl {
     protected final boolean multiProfile;
     protected final Vertx vertx;
 
-    protected HttpActionAdapter<Void, VertxWebContext> httpActionAdapter = new DefaultHttpActionAdapter();
+    protected final HttpActionAdapter<Void, VertxWebContext> httpActionAdapter = new DefaultHttpActionAdapter();
 
     private final SecurityLogic<Void, VertxWebContext> securityLogic;
 
@@ -67,11 +67,12 @@ public class SecurityHandler extends AuthHandlerImpl {
         // be blocking) so we have to wrap the following call in an executeBlocking call to avoid blocking the
         // event loop
         final VertxWebContext webContext = new VertxWebContext(routingContext);
+
         vertx.executeBlocking(future -> securityLogic.perform(webContext, config,
             (ctx, parameters) -> {
                 // This is what should occur if we are authenticated and authorized to view the requested
                 // resource
-                LOG.debug("Authorised to view resource " + routingContext.request().path());
+                LOG.info("Authorised to view resource " + routingContext.request().path());
                 routingContext.next();
                 return null;
             },

--- a/src/test/java/org/pac4j/vertx/StatefulPac4jAuthHandlerIntegrationTest.java
+++ b/src/test/java/org/pac4j/vertx/StatefulPac4jAuthHandlerIntegrationTest.java
@@ -40,6 +40,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
  * @author Jeremy Prime
  * @since 2.0.0
  */
+@SuppressWarnings("RedundantThrows")
 public class StatefulPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerIntegrationTestBase {
 
     private static final String TEST_CLIENT_ID = "testClient";
@@ -48,11 +49,13 @@ public class StatefulPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerInt
     private static final String LOGOUT_URL_FOR_CLIENT = "/logout?url=/";
 
     private static final Logger LOG = LoggerFactory.getLogger(StatefulPac4jAuthHandlerIntegrationTest.class);
+    private static final String TEST_OAUTH_2_CLIENT_NAME = "TestOAuth2Client";
+    private static final String FIELD_ACCESS_TOKEN = "access_token";
 
     // This will be our session cookie header for use by requests
-    protected AtomicReference<String> sessionCookie = new AtomicReference<>();
+    private final AtomicReference<String> sessionCookie = new AtomicReference<>();
 
-    public void startOAuth2ProviderMimic(final String userIdToReturn) throws Exception {
+    private void startOAuth2ProviderMimic(final String userIdToReturn) throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         final OAuth2ProviderMimic mimic = new OAuth2ProviderMimic(userIdToReturn);
 
@@ -161,8 +164,10 @@ public class StatefulPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerInt
     }
 
     @Override
-    protected void validateProtectedResourceContent(JsonObject jsonObject) {
-        assertThat(jsonObject.getString("access_token"), is(notNullValue()));
+    protected void validateProtectedResourceContent(final JsonObject jsonObject) {
+        assertThat(jsonObject
+                .getJsonObject(TEST_OAUTH_2_CLIENT_NAME)
+                .getString(FIELD_ACCESS_TOKEN), is(notNullValue()));
     }
 
     private void loginSuccessfullyExpectingAuthorizedUser(final Consumer<Void> subsequentActions) throws Exception {
@@ -213,7 +218,7 @@ public class StatefulPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerInt
                         expectAndHandleRedirect(client, clientResponse -> {},
                                 // redirect to original url if authorized
                                 expectAndHandleRedirect(client, httpClientResponse -> {},
-                                        finalResponseHandler::handle)))
+                                        finalResponseHandler)))
         )
                 .end();
 

--- a/src/test/java/org/pac4j/vertx/StatelessPac4jAuthHandlerIntegrationTest.java
+++ b/src/test/java/org/pac4j/vertx/StatelessPac4jAuthHandlerIntegrationTest.java
@@ -31,13 +31,13 @@ public class StatelessPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerIn
 
     private static final String AUTH_HEADER_NAME = "Authorization";
     private static final String BASIC_AUTH_PREFIX = "Basic ";
-    public static final String TEST_USER_NAME = "testUser";
+    private static final String TEST_USER_NAME = "testUser";
     private static final String TEST_BASIC_AUTH_HEADER = BASIC_AUTH_PREFIX + Base64.encodeBase64String((TEST_USER_NAME + ":testUser").getBytes());
     private static final String TEST_FAILING_BASIC_AUTH_HEADER = BASIC_AUTH_PREFIX + Base64.encodeBase64String((TEST_USER_NAME + ":testUser2").getBytes());
-    public static final String PROTECTED_RESOURCE_URL = "/private/success.html";
-    public static final String BASIC_AUTH_CLIENT = "BasicAuthClient";
+    private static final String PROTECTED_RESOURCE_URL = "/private/success.html";
+    private static final String BASIC_AUTH_CLIENT = "BasicAuthClient";
     private static final String USERNAME_FIELD = "username";
-    public static final String EXCLUDED_PATH_MATCHER_NAME = "ExcludedPathMatcher";
+    private static final String EXCLUDED_PATH_MATCHER_NAME = "ExcludedPathMatcher";
 
     @Test
     public void testSuccessfulLogin() throws Exception {
@@ -65,10 +65,12 @@ public class StatelessPac4jAuthHandlerIntegrationTest extends Pac4jAuthHandlerIn
 
     @Override
     protected void validateProtectedResourceContent(JsonObject jsonObject) {
-        assertThat(jsonObject.getString(USERNAME_FIELD), is(TEST_USER_NAME));
+        assertThat(jsonObject
+                .getJsonObject(BASIC_AUTH_CLIENT)
+                .getString(USERNAME_FIELD), is(TEST_USER_NAME));
     }
 
-    protected Consumer<String> unprotectedResourceContentValidator() {
+    private Consumer<String> unprotectedResourceContentValidator() {
         return s -> s.equals(UNPROTECTED_RESOURCE_BODY);
     }
 

--- a/src/test/java/org/pac4j/vertx/auth/Pac4jUserTest.java
+++ b/src/test/java/org/pac4j/vertx/auth/Pac4jUserTest.java
@@ -17,16 +17,18 @@ public class Pac4jUserTest {
     private static final String TEST_CLIENT = "testClient";
 
     @Test
-    public void testClusterSerializationAndDeserialization() throws Exception {
+    public void testClusterSerializationAndDeserializationSingleProfile() throws Exception {
         final CommonProfile profileToSerialize = new TestOAuth1Profile();
         profileToSerialize.setId(TEST_USER_ID);
         profileToSerialize.setClientName(TEST_CLIENT);
-        final Pac4jUser userToSerialize = new Pac4jUser(profileToSerialize);
+        final Pac4jUser userToSerialize = new Pac4jUser();
+        userToSerialize.setUserProfile(TEST_CLIENT, profileToSerialize, false);
         final Buffer buf = Buffer.buffer();
         userToSerialize.writeToBuffer(buf);
         final Pac4jUser deserializedUser = new Pac4jUser();
         deserializedUser.readFromBuffer(0, buf);
-        assertThat(deserializedUser.pac4jUserProfile().getId(), is(TEST_USER_ID));
+        final CommonProfile profile = deserializedUser.pac4jUserProfiles().get(TEST_CLIENT);
+        assertThat(profile.getId(), is(TEST_USER_ID));
         assertThat(deserializedUser.principal().encodePrettily(),
                 is(userToSerialize.principal().encodePrettily()));
     }

--- a/src/test/java/org/pac4j/vertx/cas/ClusteredSharedDataLogoutHandlerIntegrationTest.java
+++ b/src/test/java/org/pac4j/vertx/cas/ClusteredSharedDataLogoutHandlerIntegrationTest.java
@@ -56,20 +56,20 @@ public class  ClusteredSharedDataLogoutHandlerIntegrationTest extends VertxTestB
     private static final String USER_ID = "userId";
     private static final String STORED_SESSION_ID = "storedSessionId";
 
-    public static final String QUERY_STATE_URL = "/cas_state";
+    private static final String QUERY_STATE_URL = "/cas_state";
     private static final String TEST_USER_ID = "testUser1";
     private static final String SESSION_ID = "sessionId";
-    public static final String CAS_CLIENT_NAME = "casClient";
-    public static final String TEST_TICKET = "testTicket";
-    public static final String CAS_LOGIN_URL = "http://localhost:8080/";
-    public static final String SERVICE_VALIDATE_URL = "/serviceValidate";
-    public static final String CALLBACK_URL = "/callback";
+    private static final String CAS_CLIENT_NAME = "casClient";
+    private static final String TEST_TICKET = "testTicket";
+    private static final String CAS_LOGIN_URL = "http://localhost:8080/";
+    private static final String SERVICE_VALIDATE_URL = "/serviceValidate";
+    private static final String CALLBACK_URL = "/callback";
 
     private Vertx clusteredVertx;
     private io.vertx.rxjava.core.Vertx rxVertx;
 
     // This will be our session cookie header for use by requests
-    protected AtomicReference<String> sessionCookie = new AtomicReference<>();
+    protected final AtomicReference<String> sessionCookie = new AtomicReference<>();
 
     @Before
     public void clearSessionCookie() {
@@ -278,7 +278,7 @@ public class  ClusteredSharedDataLogoutHandlerIntegrationTest extends VertxTestB
             rc.response().setStatusCode(200).end(casTicketValidationResponse());
     }
 
-    private ProfileManager<CasProfile> profileManager(final RoutingContext routingContext) {
+    private ProfileManager profileManager(final RoutingContext routingContext) {
         return new VertxProfileManager(new VertxWebContext((io.vertx.ext.web.RoutingContext) routingContext.getDelegate()));
     }
 

--- a/src/test/java/org/pac4j/vertx/cas/VertxClusteredSharedDataLogoutHandlerTest.java
+++ b/src/test/java/org/pac4j/vertx/cas/VertxClusteredSharedDataLogoutHandlerTest.java
@@ -44,10 +44,10 @@ public class VertxClusteredSharedDataLogoutHandlerTest extends VertxSharedDataLo
                 final Vertx clusteredVertx = asyncResult.result();
                 final SessionStore sessionStore = LocalSessionStore.create(clusteredVertx);
                 clusteredVertx.<String>executeBlocking(future -> {
-                            String expectedSessionid = null;
+                            String expectedSessionId = null;
                             try {
-                                expectedSessionid = recordSession(new VertxClusteredSharedDataLogoutHandler(clusteredVertx, sessionStore), sessionStore);
-                                future.complete(expectedSessionid);
+                                expectedSessionId = recordSession(new VertxClusteredSharedDataLogoutHandler(clusteredVertx, sessionStore), sessionStore);
+                                future.complete(expectedSessionId);
                             } catch (Exception e) {
                                future.fail(e);
                             }
@@ -131,12 +131,13 @@ public class VertxClusteredSharedDataLogoutHandlerTest extends VertxSharedDataLo
         }, false)
         .doOnError(sessionDestructionFuture::completeExceptionally)
         .subscribe(sessionDestructionFuture::complete);
-        sessionDestructionFuture.get(1, TimeUnit.SECONDS); // Wait till we think session destruction is complete or we timeo
+        sessionDestructionFuture.get(1, TimeUnit.SECONDS); // Wait till we think session destruction is complete or
+                                                           // we timeout
 
         // Now check final state
         final String actualSessionId = getFromAsyncMap(clusteredVertx, TEST_TICKET);
         assertThat(actualSessionId, is(nullValue()));
-        final UserProfile profileFromSession = new VertxProfileManager<>(webContext).get(true).orElse(null);
+        final UserProfile profileFromSession = new VertxProfileManager(webContext).get(true).orElse(null);
         assertThat(profileFromSession, is(nullValue()));
 
     }

--- a/src/test/java/org/pac4j/vertx/cas/VertxLocalSharedDataLogoutHandlerTest.java
+++ b/src/test/java/org/pac4j/vertx/cas/VertxLocalSharedDataLogoutHandlerTest.java
@@ -51,7 +51,7 @@ public class VertxLocalSharedDataLogoutHandlerTest extends VertxSharedDataLogout
         final String sessionIdFromSharedData = (String) vertx.sharedData().getLocalMap(VertxSharedDataLogoutHandler.PAC4J_CAS_SHARED_DATA_KEY)
                 .get(TEST_TICKET);
         assertThat(sessionIdFromSharedData, is(nullValue()));
-        final CommonProfile userProfileFromSession = new VertxProfileManager<>(context).get(true).orElse(null);
+        final CommonProfile userProfileFromSession = new VertxProfileManager(context).get(true).orElse(null);
         assertThat(userProfileFromSession, is(nullValue()));
     }
 

--- a/src/test/kotlin/org/pac4j/vertx/handler/impl/Functions.kt
+++ b/src/test/kotlin/org/pac4j/vertx/handler/impl/Functions.kt
@@ -17,7 +17,6 @@ import org.pac4j.core.config.Config
 import org.pac4j.vertx.VertxProfileManager
 import org.pac4j.vertx.VertxWebContext
 import org.pac4j.vertx.auth.Pac4jAuthProvider
-import org.pac4j.vertx.profile.TestOAuth1Profile
 import rx.Observable
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
@@ -65,7 +64,7 @@ fun logoutHandler(vertx: io.vertx.core.Vertx): Handler<RoutingContext> {
 }
 
 
-fun getProfileManager(rc: RoutingContext): VertxProfileManager<TestOAuth1Profile> {
+fun getProfileManager(rc: RoutingContext): VertxProfileManager {
     val webContext = VertxWebContext(rc.delegate as io.vertx.ext.web.RoutingContext)
     return VertxProfileManager(webContext)
 }


### PR DESCRIPTION
Issue #72 Implement multi-profile support in vertx-pac4j

Multi-profile support in vertx-pac4j implies the need for a map of user profiles within the Pac4jUser instead of just one user profile.

This has implications for serialization for clustered sessions, so this commit will, if applied, make multi-profile support possible within the Pac4j user and also provide a test for serialization/deserialization using existing mechanisms to make sure clustered sessions will adequately be supported.

It will not provide full implementation of multi-profile behaviour in the handler or tests for this - these will be added in a subsequent commit, but this commit is a necessary building block for multi profile support.