### PR TITLE
#82 Ensure tests route log output to slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <kotlin.version>1.0.5</kotlin.version>
     <mockito.version>1.10.19</mockito.version>
     <surefire.version>2.19.1</surefire.version>
+    <slf4j.version>1.7.22</slf4j.version>
   </properties>
 
   <dependencies>
@@ -121,6 +122,13 @@
       <version>${kotlin.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- logging for tests -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 
@@ -161,6 +169,16 @@
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <systemPropertyVariables>
+            <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration debug="true"
+                     xmlns:log4j='http://jakarta.apache.org/log4j/'>
+
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                   value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" />
+        </layout>
+    </appender>
+
+    <root>
+        <level value="INFO" />
+        <appender-ref ref="console" />
+    </root>
+
+</log4j:configuration>


### PR DESCRIPTION
#82 Ensure tests route log output to slf4j

vert.x does not output logs to slf4j by default but uses JUL for its logging. If a user/developer wants to use slf4j logging it is for them to configure this (via a system property and import of appropriate dependencies)

In keeping with the vert.x standards, the vertx-pac4j code follows the same standard (but can be made via config to route to slf4j). This commit, will, if merged, ensure that for the tests, when run through maven, all the standard vertx logging is routed to slf4j and can therefore be reviewed in tandem with the slf4j logging generated within pac4j.