### PR TITLE
getSessionFunctionNeedReturnNullWhenSessionidNotExsits

### DIFF
--- a/src/main/java/org/pac4j/vertx/context/session/VertxSessionStore.java
+++ b/src/main/java/org/pac4j/vertx/context/session/VertxSessionStore.java
@@ -67,7 +67,13 @@ public class VertxSessionStore implements ExtendedSessionStore<VertxWebContext> 
                 vertxSessionFuture.completeExceptionally(asyncResult.cause());
             }
         });
-        final CompletableFuture<Session> pac4jSessionFuture = vertxSessionFuture.thenApply(s -> new VertxSession(s));
+        final CompletableFuture<Session> pac4jSessionFuture = vertxSessionFuture.thenApply(session -> {
+            if (session != null) {
+                return new VertxSession(session);
+            } else {
+                return null;
+            }
+        });
         try {
             return pac4jSessionFuture.get();
         } catch (InterruptedException|ExecutionException e) {


### PR DESCRIPTION
If the session id does not exist, `org.pac4j.vertx.context.session.VertxSession` should not be created, otherwise the null pointer error will be reported on line 153 of `VertxCasLogoutHandler` (`session.set(PAC4J_CAS_TICKET, null);`). Because the 152-line judgment is valid, but actually there is no `io.vertx.ext.web.Session` in the `org.pac4j.vertx.context.session.VertxSession` of the line.