### PR TITLE
upgrade to vert.x 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>3.4.2</vertx.version>
+    <vertx.version>3.5.2</vertx.version>
     <pac4j.version>2.3.1</pac4j.version>
     <java.version>1.8</java.version>
     <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>

--- a/src/main/java/org/pac4j/vertx/handler/impl/SecurityHandler.java
+++ b/src/main/java/org/pac4j/vertx/handler/impl/SecurityHandler.java
@@ -104,8 +104,7 @@ public class SecurityHandler extends AuthHandlerImpl {
             (ctx, parameters) -> {
                 // This is what should occur if we are authenticated and authorized to view the requested
                 // resource
-                LOG.info("Authorised to view resource " + routingContext.request().path());
-                routingContext.next();
+                future.complete();
                 return null;
             },
             httpActionAdapter,
@@ -119,6 +118,9 @@ public class SecurityHandler extends AuthHandlerImpl {
             // However, if an error occurred we need to handle this here
             if (asyncResult.failed()) {
                 unexpectedFailure(routingContext, asyncResult.cause());
+            } else {
+                LOG.info("Authorised to view resource " + routingContext.request().path());
+                routingContext.next();
             }
         });
 

--- a/src/main/java/org/pac4j/vertx/handler/impl/SecurityHandler.java
+++ b/src/main/java/org/pac4j/vertx/handler/impl/SecurityHandler.java
@@ -1,6 +1,9 @@
 package org.pac4j.vertx.handler.impl;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
@@ -130,4 +133,8 @@ public class SecurityHandler extends AuthHandlerImpl {
         return (t instanceof TechnicalException) ? (TechnicalException) t : new TechnicalException(t);
     }
 
+    @Override
+    public void parseCredentials(RoutingContext context, Handler<AsyncResult<JsonObject>> handler) {
+
+    }
 }


### PR DESCRIPTION
I have used the `3.1.0-SNAPSHOT` version in my project and it looks like everything is working fine. The only regret is that I had to keep an empty implementation of the `parseCredentials` method in the `org.pac4j.vertx.handler.impl.SecurityHandler` class. Or do you see there are other better ways?